### PR TITLE
fix: import path

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@ Drewc's Fork.
 Gerbil is as gerbil does.
 
 #+begin_src shell
-gxi -e "(import :drewc/r7rs/gerbil-swank)" -e "(start-swank)"
+gxi -e "(import :drewc/gerbil-swank)" -e "(start-swank)"
 #+end_src
 
 * No Handler Found


### PR DESCRIPTION
Wrong import path in readme:

```console
$ gxpkg install github.com/drewc/drewc-r7rs-swank
...

# fails
$ gxi -e "(import :drewc/r7rs/gerbil-swank)" -e "(start-swank)"
*** ERROR IN gx#core-expand-import%__% -- Syntax Error
*** ERROR IN (string)@1.9
--- Syntax Error: Cannot find library module
... form:   :drewc/r7rs/gerbil-swank

# works
$ gxi -e "(import :drewc/gerbil-swank)" -e "(start-swank)"
```